### PR TITLE
Add code styling for XPaths, SPARQL, SHACL

### DIFF
--- a/mapping_workbench/frontend/src/sections/app/conceptual-mapping-rule/list-table.js
+++ b/mapping_workbench/frontend/src/sections/app/conceptual-mapping-rule/list-table.js
@@ -59,6 +59,7 @@ import {ListSelectorSelect as ResourceListSelector} from "../../../components/ap
 import {sparqlTestFileResourcesApi} from "../../../api/sparql-test-suites/file-resources";
 import {toastSuccess} from "../../../components/app-toast";
 import {TermValidityInfo} from "./term-validity";
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 
 export const ListTableTripleMapFragment = (props) => {
@@ -934,7 +935,14 @@ export const ListTableRow = (props) => {
                                         {item.source_structural_element.absolute_xpath && <PropertyListItem
                                             key="absolute_xpath"
                                             label="Absolute XPath"
-                                            value={item.source_structural_element.absolute_xpath}
+                                            value={
+                                                <SyntaxHighlighter
+                                                    language="xquery"
+                                                    wrapLines={true}
+                                                    lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }}>
+                                                    {item.source_structural_element.absolute_xpath}
+                                                </SyntaxHighlighter>
+                                            }
                                         />}
                                     </>
                                 )}
@@ -949,11 +957,27 @@ export const ListTableRow = (props) => {
                                         Target
                                      </Typography>
                                      {!!item.target_class_path_terms_validity.length &&
-                                         <PropertyListItem label='Ontology Fragment Class path'
-                                                           value={parse(targetClassPathValidityInfo)}/>}
+                                        <PropertyListItem
+                                            label='Ontology Fragment Class path'
+                                            value={
+                                                <SyntaxHighlighter
+                                                    language="sparql"
+                                                    wrapLines={true}
+                                                    lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }}>
+                                                    {item.target_class_path}
+                                                </SyntaxHighlighter>
+                                            } />}
                                      {!!item.target_property_path_terms_validity.length &&
-                                        <PropertyListItem label='Ontology Fragment Property path'
-                                                          value={parse(targetPropertyPathValidityInfo)}/>}
+                                        <PropertyListItem
+                                            label='Ontology Fragment Property path'
+                                            value={
+                                                <SyntaxHighlighter
+                                                    language="sparql"
+                                                    wrapLines={true}
+                                                    lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }}>
+                                                    {item.target_property_path}
+                                                </SyntaxHighlighter>
+                                            } />}
                                 </PropertyList>}
                         </Grid>
                     </Grid>

--- a/mapping_workbench/frontend/src/sections/app/fields-registry/basic-details.js
+++ b/mapping_workbench/frontend/src/sections/app/fields-registry/basic-details.js
@@ -4,6 +4,7 @@ import ListItem from "@mui/material/ListItem";
 
 import {PropertyList} from 'src/components/property-list';
 import {PropertyListItem} from 'src/components/property-list-item';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export const BasicDetails = (props) => {
     const {item, ...other} = props;
@@ -30,12 +31,12 @@ export const BasicDetails = (props) => {
                     <PropertyListItem
                         divider
                         label="Absolute XPath"
-                        value={item.absolute_xpath}
+                        value={<SyntaxHighlighter language="xquery">{item.absolute_xpath}</SyntaxHighlighter>}
                     />
                     <PropertyListItem
                         divider
                         label="Relative XPath"
-                        value={item.relative_xpath}
+                        value={<SyntaxHighlighter language="xquery">{item.relative_xpath}</SyntaxHighlighter>}
                     />
                     <PropertyListItem
                         divider

--- a/mapping_workbench/frontend/src/sections/app/fields-registry/list-table.js
+++ b/mapping_workbench/frontend/src/sections/app/fields-registry/list-table.js
@@ -25,6 +25,7 @@ import {ListItemActions} from 'src/components/app/list/list-item-actions';
 import {ForListItemAction} from 'src/contexts/app/section/for-list-item-action';
 import {PropertyList} from "../../../components/property-list";
 import {PropertyListItem} from "../../../components/property-list-item";
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 
 export const ListTable = (props) => {
@@ -220,7 +221,14 @@ export const ListTable = (props) => {
                                                             <PropertyList>
                                                                 <PropertyListItem
                                                                     label="Absolute XPath"
-                                                                    value={item.absolute_xpath}
+                                                                    value={
+                                                                        <SyntaxHighlighter
+                                                                            language="xquery"
+                                                                            wrapLines={true}
+                                                                            lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }}>
+                                                                            {item.absolute_xpath}
+                                                                        </SyntaxHighlighter>
+                                                                    }
                                                                     sx={{
                                                                         whiteSpace: "pre-wrap",
                                                                         px: 3,
@@ -229,7 +237,14 @@ export const ListTable = (props) => {
                                                                 />
                                                                 <PropertyListItem
                                                                     label="Relative XPath"
-                                                                    value={item.relative_xpath}
+                                                                    value={
+                                                                        <SyntaxHighlighter
+                                                                            language="xquery"
+                                                                            wrapLines={true}
+                                                                            lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }}>
+                                                                            {item.relative_xpath}
+                                                                        </SyntaxHighlighter>
+                                                                    }
                                                                     sx={{
                                                                         whiteSpace: "pre-wrap",
                                                                         px: 3,

--- a/mapping_workbench/frontend/src/sections/app/shacl_validation_report/list-table-file.js
+++ b/mapping_workbench/frontend/src/sections/app/shacl_validation_report/list-table-file.js
@@ -9,6 +9,7 @@ import TableRow from '@mui/material/TableRow';
 import {Scrollbar} from 'src/components/scrollbar';
 import PropTypes from 'prop-types';
 import {SorterHeader as UtilsSorterHeader} from "./utils";
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export const ListTableFile = (props) => {
 
@@ -71,22 +72,46 @@ export const ListTableFile = (props) => {
                             return (
                                 <TableRow key={key}>
                                     <TableCell width="25%">
-                                        {item.focus_node}
+                                        <SyntaxHighlighter
+                                            language="turtle"
+                                            wrapLines={true}
+                                            lineProps={{ style: { overflowWrap: 'break-word', whiteSpace: 'pre-wrap' } }}>
+                                            {item.focus_node}
+                                        </SyntaxHighlighter>
                                     </TableCell>
                                     <TableCell>
-                                        {item.message}
+                                        <SyntaxHighlighter
+                                            language="turtle"
+                                            wrapLines={true}
+                                            lineProps={{ style: { overflowWrap: 'break-word', whiteSpace: 'pre-wrap' } }}>
+                                            {item.message}
+                                        </SyntaxHighlighter>
                                     </TableCell>
                                     <TableCell>
-                                        {item.result_path}
+                                        <SyntaxHighlighter
+                                            language="sparql"
+                                            wrapLines={true}
+                                            lineProps={{ style: { overflowWrap: 'break-word', whiteSpace: 'pre-wrap' } }}>
+                                            {item.result_path}
+                                        </SyntaxHighlighter>
                                     </TableCell>
                                     <TableCell>
-                                        {item.result_severity}
+                                        <SyntaxHighlighter
+                                            language="turtle"
+                                            wrapLines={true}
+                                            lineProps={{ style: { overflowWrap: 'break-word', whiteSpace: 'pre-wrap' } }}>
+                                            {item.result_severity}
+                                        </SyntaxHighlighter>
                                     </TableCell>
                                     <TableCell>
-                                        {item.source_constraint_component}
+                                        <SyntaxHighlighter
+                                            language="turtle"
+                                            wrapLines={true}
+                                            lineProps={{ style: { overflowWrap: 'break-word', whiteSpace: 'pre-wrap' } }}>
+                                            {item.source_constraint_component}
+                                        </SyntaxHighlighter>
                                     </TableCell>
                                 </TableRow>
-
                             );
                         })}
                     </TableBody>

--- a/mapping_workbench/frontend/src/sections/app/shacl_validation_report/list-table.js
+++ b/mapping_workbench/frontend/src/sections/app/shacl_validation_report/list-table.js
@@ -16,6 +16,7 @@ import Stack from "@mui/material/Stack";
 
 import {Scrollbar} from 'src/components/scrollbar';
 import {ResultChip, SorterHeader as UtilsSorterHeader} from "./utils";
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export const ListTable = (props) => {
     const [descriptionDialog, setDescriptionDialog] = useState({open:false, title:"", text:""})
@@ -135,7 +136,12 @@ export const ListTable = (props) => {
                                             {0}
                                     </TableCell>
                                     <TableCell>
-                                        {item.result_path}
+                                        <SyntaxHighlighter
+                                            language="turtle"
+                                            wrapLines={true}
+                                            lineProps={{ style: { overflowWrap: 'break-word', whiteSpace: 'pre-wrap' } }}>
+                                            {item.result_path}
+                                        </SyntaxHighlighter>
                                     </TableCell>
                                     <TableCell>
                                         <ResultCell

--- a/mapping_workbench/frontend/src/sections/app/sparql_validation_report/list-table-file.js
+++ b/mapping_workbench/frontend/src/sections/app/sparql_validation_report/list-table-file.js
@@ -20,6 +20,7 @@ import Chip from "@mui/material/Chip";
 import {Scrollbar} from 'src/components/scrollbar';
 import PropTypes from 'prop-types';
 import {resultColor} from "./utils";
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export const ListTableFile = (props) => {
     const [descriptionDialog, setDescriptionDialog] = useState({open:false, title:"", text:""})
@@ -113,7 +114,12 @@ export const ListTableFile = (props) => {
                                         </Button>
                                     </TableCell>
                                     <TableCell>
-                                        {item.query}
+                                        <SyntaxHighlighter
+                                            language="sparql"
+                                            wrapLines={true}
+                                            lineProps={{ style: { overflowWrap: 'break-word', whiteSpace: 'pre-wrap' } }}>
+                                            {item.query}
+                                        </SyntaxHighlighter>
                                     </TableCell>
                                     <TableCell align="left">
                                         <Chip label={item.result}

--- a/mapping_workbench/frontend/src/sections/app/sparql_validation_report/list-table.js
+++ b/mapping_workbench/frontend/src/sections/app/sparql_validation_report/list-table.js
@@ -19,6 +19,7 @@ import Stack from "@mui/material/Stack";
 
 import {Scrollbar} from 'src/components/scrollbar';
 import {ResultChip} from "./utils";
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export const ListTable = (props) => {
     const [descriptionDialog, setDescriptionDialog] = useState({open:false, title:"", description:""})
@@ -159,7 +160,12 @@ export const ListTable = (props) => {
                                         {item.test_suite}
                                     </TableCell>
                                     <TableCell>
-                                        {item.query}
+                                        <SyntaxHighlighter
+                                            language="sparql"
+                                            wrapLines={true}
+                                            lineProps={{ style: { overflowWrap: 'break-word', whiteSpace: 'pre-wrap' } }}>
+                                            {item.query}
+                                        </SyntaxHighlighter>
                                     </TableCell>
                                     <TableCell>
                                         <ResultCell

--- a/mapping_workbench/frontend/src/sections/app/xpath_validation_report/list-table-file.js
+++ b/mapping_workbench/frontend/src/sections/app/xpath_validation_report/list-table-file.js
@@ -20,6 +20,7 @@ import CloseIcon from '@mui/icons-material/Close';
 
 import {Scrollbar} from 'src/components/scrollbar';
 import PropTypes from 'prop-types';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export const ListTable = (props) => {
     const [descriptionDialog, setDescriptionDialog] = useState({open:false, title:"", text:""})
@@ -94,7 +95,14 @@ export const ListTable = (props) => {
                                         </Typography>
                                     </TableCell>
                                     <TableCell>
-                                        {item.eforms_sdk_element_xpath}
+                                        {
+                                            <SyntaxHighlighter
+                                                language="xquery"
+                                                wrapLines={true}
+                                                lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }}>
+                                                {item.eforms_sdk_element_xpath}
+                                            </SyntaxHighlighter>
+                                        }
                                     </TableCell>
                                     <TableCell align="center">
                                         {item.is_covered ? <CheckIcon color="success"/> : <CloseIcon color="error"/>}

--- a/mapping_workbench/frontend/src/sections/app/xpath_validation_report/list-table.js
+++ b/mapping_workbench/frontend/src/sections/app/xpath_validation_report/list-table.js
@@ -24,6 +24,7 @@ import CloseIcon from '@mui/icons-material/Close';
 
 import {Scrollbar} from 'src/components/scrollbar';
 import PropTypes from 'prop-types';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export const ListTable = (props) => {
     const [descriptionDialog, setDescriptionDialog] = useState({open:false, title:"", text:""})
@@ -102,7 +103,14 @@ export const ListTable = (props) => {
                                         </Typography>
                                     </TableCell>
                                     <TableCell>
-                                        {item.eforms_sdk_element_xpath}
+                                        {
+                                            <SyntaxHighlighter
+                                                language="xquery"
+                                                wrapLines={true}
+                                                lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }}>
+                                                {item.eforms_sdk_element_xpath}
+                                            </SyntaxHighlighter>
+                                        }
                                     </TableCell>
                                      <TableCell>
                                          <Accordion


### PR DESCRIPTION
It is desireable to view code text formatted nicely, for which we can exploit the Prism syntax highlighter.

- The SHACL detailed report is simply a table of RDF resources, so all columns are styled as Turtle.

- It is possible to add a scrollbar in some places simply by not wrapping (e.g. in the Conceptual Mapping Rules)

- Wrapping needs to be either an overflowWrap or a wordBreak depending on where the component is placed (table/grid/PropertyListItem).

Otherwise, this needs refactoring in some way to inherit the theme (there is theme, i.e. "style" support in the highlighter)

**Conceptual Mappings**

![image](https://github.com/meaningfy-ws/mapping-workbench/assets/1151152/d8ba8023-8fe9-4bae-ae10-fa9205f93d32)

**Fields Registry**

![image](https://github.com/meaningfy-ws/mapping-workbench/assets/1151152/1fbdafef-27e3-4403-8ab6-4b00ad1567fb)

**XPath Report**

![image](https://github.com/meaningfy-ws/mapping-workbench/assets/1151152/2d899fdf-ca30-47f9-ba5b-1b00698e7d03)

**SPARQL Report**

![image](https://github.com/meaningfy-ws/mapping-workbench/assets/1151152/227de535-2750-494e-858f-170988a1dc1a)

**SPARQL Report - Details**

![image](https://github.com/meaningfy-ws/mapping-workbench/assets/1151152/872b9338-a0cb-4944-bf94-466e37f63d90)

**SHACL Report**

![image](https://github.com/meaningfy-ws/mapping-workbench/assets/1151152/eb98b944-de21-41fb-8c6a-9ee18a14ea79)

**SHACL Report - Details**

![image](https://github.com/meaningfy-ws/mapping-workbench/assets/1151152/074c48c4-4610-4573-9dc1-86df0fd7d3d5)
