### PR TITLE
Log and print important debugging information in BE

### DIFF
--- a/mapping_workbench/backend/fields_registry/adapters/github_download.py
+++ b/mapping_workbench/backend/fields_registry/adapters/github_download.py
@@ -3,6 +3,9 @@ import shutil
 import subprocess
 import tempfile
 from typing import List
+import logging
+
+logger = logging.getLogger("uvicorn")
 
 
 class GithubDownloader:
@@ -28,11 +31,14 @@ class GithubDownloader:
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_dir_path = pathlib.Path(tmp_dir)
             bash_script = f"cd {temp_dir_path} && git clone --depth=1 --single-branch --branch {self.branch_or_tag_name} {self.github_repository_url}"
+            logger.info(f"Running command {bash_script}")
             subprocess.run(bash_script, shell=True,
                            stdout=subprocess.DEVNULL,
                            stderr=subprocess.STDOUT)
             dir_contents = list(temp_dir_path.iterdir())
+            logger.info(f"Downloaded path {dir_contents}")
 
+            # FIXME this is not good, we should raise an exception instead
             assert len(dir_contents) == 1
             repository_name = dir_contents[0].name
 

--- a/mapping_workbench/backend/package_validator/adapters/sparql_validator.py
+++ b/mapping_workbench/backend/package_validator/adapters/sparql_validator.py
@@ -36,6 +36,7 @@ class SPARQLValidator(TestDataValidator):
         results = []
 
         for sparql_query in sparql_queries:
+            print("            Running assertion for", sparql_query.cm_rule.eforms_sdk_element_title)
             sparql_query_result: SPARQLQueryResult = SPARQLQueryResult(
                 query=sparql_query,
                 result=None,

--- a/mapping_workbench/backend/package_validator/services/sparql_validator.py
+++ b/mapping_workbench/backend/package_validator/services/sparql_validator.py
@@ -18,6 +18,7 @@ def validate_tests_data_with_sparql_tests(
 
     """
     for idx, test_data in enumerate(tests_data):
+        print("       ", test_data.filename)
         try:
             if test_data.rdf_manifestation is None:
                 raise TestDataException("Test data must have a rdf manifestation")

--- a/mapping_workbench/backend/test_data_suite/services/transform_test_data.py
+++ b/mapping_workbench/backend/test_data_suite/services/transform_test_data.py
@@ -129,6 +129,7 @@ async def transform_test_data_file_resources(
     rml_mapper: RMLMapper = RMLMapper(rml_mapper_path=Path(settings.RML_MAPPER_PATH))
 
     for test_data_file_resource in test_data_file_resources:
+        print("       ", test_data_file_resource.filename)
         await transform_test_data_file_resource(
             test_data_file_resource=test_data_file_resource,
             user=user,


### PR DESCRIPTION
We need visibility into the important steps and processes of the API, long-running or not.

For code where `print()` is already in use, continue printing out. Elsewhere, log out reusing the server's (`uvicorn`) default logger.