### PR TITLE
add timezone in datetime in entire project

### DIFF
--- a/mapping_workbench/backend/__init__.py
+++ b/mapping_workbench/backend/__init__.py
@@ -9,3 +9,5 @@ STRICT_MODEL_CONFIG = ConfigDict(extra='forbid',
                                   revalidate_instances='always',
                                   validate_default=True,
                                   validate_return=True)
+
+DEFAULT_TIMEZONE = 'UTC'

--- a/mapping_workbench/backend/conceptual_mapping_rule/models/entity.py
+++ b/mapping_workbench/backend/conceptual_mapping_rule/models/entity.py
@@ -4,7 +4,8 @@ from typing import Optional, List
 
 import pymongo
 from beanie import Link, PydanticObjectId
-from pydantic import BaseModel
+from dateutil.tz import tzlocal
+from pydantic import BaseModel, Field
 from pymongo import IndexModel
 
 from mapping_workbench.backend.core.models.base_project_resource_entity import BaseProjectResourceEntity, \
@@ -37,7 +38,7 @@ class ConceptualMappingRuleComment(BaseModel):
     title: Optional[str] = None
     comment: Optional[str] = None
     priority: Optional[ConceptualMappingRuleCommentPriority] = ConceptualMappingRuleCommentPriority.NORMAL
-    created_at: Optional[datetime] = None
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now(tzlocal()))
     created_by: Optional[Link[User]] = None
     updated_at: Optional[datetime] = None
     updated_by: Optional[Link[User]] = None

--- a/mapping_workbench/backend/core/models/base_entity.py
+++ b/mapping_workbench/backend/core/models/base_entity.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from beanie import Document, Link, PydanticObjectId
+from dateutil.tz import tzlocal
 from pydantic import BaseModel, Field, Extra, ConfigDict
 
 from mapping_workbench.backend.user.models.user import User
@@ -11,7 +12,7 @@ class BaseEntity(Document):
     """
     The general model for entities
     """
-    created_at: Optional[datetime] = None
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now(tzlocal()))
     updated_at: Optional[datetime] = None
     created_by: Optional[Link[User]] = None
     updated_by: Optional[Link[User]] = None
@@ -21,13 +22,13 @@ class BaseEntity(Document):
         if user:
             self.created_by = User.link_from_id(user.id)
         if not self.created_at:
-            self.created_at = datetime.now()
+            self.created_at = datetime.now(tzlocal())
         return self
 
     def on_update(self, user: User):
         if user:
             self.updated_by = User.link_from_id(user.id)
-        self.updated_at = datetime.now()
+        self.updated_at = datetime.now(tzlocal())
         return self
 
     class Settings:
@@ -40,7 +41,7 @@ class BaseEntityOutSchema(BaseModel):
     # is_deleted: Optional[bool]
     # created_by: Optional[Any]
     # updated_by: Optional[Any]
-    created_at: Optional[datetime] = None
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now(tzlocal()))
     updated_at: Optional[datetime] = None
 
     model_config = ConfigDict(

--- a/mapping_workbench/backend/core/services/request.py
+++ b/mapping_workbench/backend/core/services/request.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from beanie import Link, PydanticObjectId
+from dateutil.tz import tzlocal
 from pydantic import BaseModel
 
 from mapping_workbench.backend.core.models.base_entity import BaseEntity
@@ -17,7 +18,7 @@ def request_update_data(entity_data: BaseModel, user: User = None) -> dict:
 
     if user:
         data['updated_by'] = User.link_from_id(user.id)
-    data['updated_at'] = datetime.now()
+    data['updated_at'] = datetime.now(tzlocal())
 
     return data
 
@@ -27,7 +28,7 @@ def request_create_data(entity_data: BaseModel, user: User = None) -> dict:
 
     if user:
         data['created_by'] = User.link_from_id(user.id)
-    data['created_at'] = datetime.now()
+    data['created_at'] = datetime.now(tzlocal())
 
     return data
 

--- a/mapping_workbench/backend/logger/models/logger_record.py
+++ b/mapping_workbench/backend/logger/models/logger_record.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, model_validator
+from dateutil.tz import tzlocal
+from pydantic import BaseModel, model_validator, Field
 from typing_extensions import Self
 
 from mapping_workbench.backend import STRICT_MODEL_CONFIG
@@ -18,7 +19,7 @@ class LogRecord(BaseModel):
 
     log_severity: LogSeverity
     message: str
-    timestamp: Optional[datetime] = datetime.utcnow()
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(tzlocal()))
     stack_trace: Optional[str] = None
 
     @model_validator(mode='after')

--- a/mapping_workbench/backend/mapping_package/models/entity.py
+++ b/mapping_workbench/backend/mapping_package/models/entity.py
@@ -4,7 +4,8 @@ from typing import Optional, List
 import pymongo
 from beanie import Indexed, Link, PydanticObjectId
 from beanie.odm.operators.find.comparison import Eq, NE
-from pydantic import BaseModel
+from dateutil.tz import tzlocal
+from pydantic import BaseModel, Field
 from pymongo import IndexModel
 
 from mapping_workbench.backend.conceptual_mapping_rule.models.entity import ConceptualMappingRuleState, \
@@ -40,8 +41,8 @@ class MappingPackageIn(BaseProjectResourceEntityInSchema):
     mapping_version: str = None
     epo_version: str = None
     eform_subtypes: List[str] = None
-    start_date: Optional[str] = None
-    end_date: Optional[str] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
     eforms_sdk_versions: List[str] = None
     shacl_test_suites: Optional[List[Optional[Link[SHACLTestSuite]]]] = None
 
@@ -55,7 +56,7 @@ class MappingPackageUpdateIn(MappingPackageIn):
 
 
 class MappingPackageImportIn(MappingPackageIn):
-    created_at: Optional[datetime] = None
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now(tzlocal()))
 
 
 class MappingPackageOut(BaseProjectResourceEntityOutSchema):
@@ -65,8 +66,8 @@ class MappingPackageOut(BaseProjectResourceEntityOutSchema):
     mapping_version: str = None
     epo_version: str = None
     eform_subtypes: List[str] = None
-    start_date: Optional[str] = None
-    end_date: Optional[str] = None
+    #start_date: Optional[datetime] = None
+    #end_date: Optional[datetime] = None
     eforms_sdk_versions: List[str] = None
     shacl_test_suites: Optional[List[Link[SHACLTestSuite]]] = None
 
@@ -83,7 +84,7 @@ class MappingPackageState(TestDataValidation, ObjectState):
     identifier: Optional[str] = None
     mapping_version: str = None
     epo_version: str = None
-    created_at: Optional[datetime] = None
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now(tzlocal()))
     eform_subtypes: List[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None

--- a/mapping_workbench/backend/mapping_package/services/api.py
+++ b/mapping_workbench/backend/mapping_package/services/api.py
@@ -3,11 +3,13 @@ from typing import List
 import pymongo
 from beanie import PydanticObjectId
 from pymongo.errors import DuplicateKeyError
+from pytz import timezone
 
 from mapping_workbench.backend.core.models.base_entity import BaseEntityFiltersSchema
 from mapping_workbench.backend.core.services.exceptions import ResourceNotFoundException, DuplicateKeyException
 from mapping_workbench.backend.core.services.request import request_update_data, request_create_data, \
     api_entity_is_found, prepare_search_param, pagination_params
+from mapping_workbench.backend.logger.services import mwb_logger
 from mapping_workbench.backend.mapping_package.models.entity import MappingPackage, MappingPackageCreateIn, \
     MappingPackageUpdateIn, MappingPackageOut, MappingPackageStateGate
 from mapping_workbench.backend.user.models.user import User
@@ -27,6 +29,11 @@ async def list_mapping_packages(filters: dict = None, page: int = None, limit: i
         skip=skip,
         limit=limit
     ).to_list()
+
+    # Unfortunately beanie at the moment can't retrieve timezone from mongodb
+    for item in items:
+        item.created_at = item.created_at.astimezone(timezone('UTC'))
+
     total_count: int = await MappingPackage.find(query_filters).count()
     return items, total_count
 

--- a/mapping_workbench/backend/mapping_package/services/api.py
+++ b/mapping_workbench/backend/mapping_package/services/api.py
@@ -30,10 +30,6 @@ async def list_mapping_packages(filters: dict = None, page: int = None, limit: i
         limit=limit
     ).to_list()
 
-    # Unfortunately beanie at the moment can't retrieve timezone from mongodb
-    for item in items:
-        item.created_at = item.created_at.astimezone(timezone('UTC'))
-
     total_count: int = await MappingPackage.find(query_filters).count()
     return items, total_count
 

--- a/mapping_workbench/backend/package_validator/models/test_data_validation.py
+++ b/mapping_workbench/backend/package_validator/models/test_data_validation.py
@@ -2,14 +2,15 @@ from datetime import datetime
 from typing import Optional
 
 from beanie import PydanticObjectId
-from pydantic import BaseModel
+from dateutil.tz import tzlocal
+from pydantic import BaseModel, Field
 
 
 class TestDataValidationResult(BaseModel):
     """
 
     """
-    created_at: Optional[datetime] = datetime.now()
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now(tzlocal()))
 
 
 class CMRuleSDKElement(BaseModel):

--- a/mapping_workbench/backend/state_manager/models/state_object.py
+++ b/mapping_workbench/backend/state_manager/models/state_object.py
@@ -2,8 +2,8 @@ import abc
 from datetime import datetime
 from typing import TypeVar, Optional
 
-from beanie import Link
-from pydantic import BaseModel
+from dateutil.tz import tzlocal
+from pydantic import BaseModel, Field
 
 from mapping_workbench.backend.user.models.user import User
 
@@ -15,14 +15,14 @@ class ObjectState(BaseModel):
     Abstract base class for to store the state of an object.
     """
 
-    created_at: Optional[datetime] = datetime.now()
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now(tzlocal()))
 
     # created_by: Optional[Link[User]] = None
 
     def on_create(self, user: User):
         # if user:
         #     self.created_by = User.link_from_id(user.id)
-        self.created_at = datetime.now()
+        self.created_at = datetime.now(tzlocal())
         return self
 
 

--- a/mapping_workbench/backend/task_manager/adapters/task.py
+++ b/mapping_workbench/backend/task_manager/adapters/task.py
@@ -1,9 +1,8 @@
-import asyncio
-import inspect
 from datetime import datetime
 from enum import Enum
 from typing import Callable, Optional, List
 
+from dateutil.tz import tzlocal
 from pebble import ProcessFuture
 from pydantic import BaseModel
 
@@ -64,14 +63,14 @@ class TaskExecutor(Callable):
 
     def __call__(self, *args, **kwargs) -> TaskResult:
         task_result = TaskResult()
-        task_result.started_at = datetime.now()
+        task_result.started_at = datetime.now(tzlocal())
         try:
             self.task_function(*args, **kwargs)
             task_result.task_status = TaskStatus.FINISHED
         except Exception as e:
             task_result.exception_message = str(e)
             task_result.task_status = TaskStatus.FAILED
-        task_result.finished_at = datetime.now()
+        task_result.finished_at = datetime.now(tzlocal())
         return task_result
 
 
@@ -104,7 +103,7 @@ class Task:
         self.task_function = TaskExecutor(task_function)
         self.task_args = args
         self.task_kwargs = kwargs
-        created_at = datetime.now()
+        created_at = datetime.now(tzlocal())
         task_id = f"{task_name}_{created_at}"
         self.task_metadata = TaskMetadata(task_id=task_id, task_name=task_name,
                                           task_timeout=task_timeout, task_status=TaskStatus.QUEUED,

--- a/tests/unit/backend/logger/conftest.py
+++ b/tests/unit/backend/logger/conftest.py
@@ -10,7 +10,6 @@ def dummy_log_record_info():
     return LogRecord(
         log_severity=LogSeverity.INFO,
         message="This is a test log message",
-        timestamp=datetime.now(),
         stack_trace=None
     )
 
@@ -19,6 +18,5 @@ def dummy_log_record_error():
     return LogRecord(
         log_severity=LogSeverity.ERROR,
         message="This is a test log message",
-        timestamp=datetime.now(),
         stack_trace="This is a test stack trace\nsomewhere in code\nalso somewhere in code\nalso here"
     )

--- a/tests/unit/backend/logger/test_logger_models.py
+++ b/tests/unit/backend/logger/test_logger_models.py
@@ -2,6 +2,7 @@ import datetime
 from types import NoneType
 
 import pytest
+from dateutil.tz import tzlocal
 
 from mapping_workbench.backend import STRICT_MODEL_CONFIG
 from mapping_workbench.backend.logger.models.logger_record import LogSeverity, LogRecord
@@ -18,12 +19,12 @@ def test_logger_record_is_strict_model(dummy_log_record_info: LogRecord,
     with pytest.raises(ValueError):
         LogRecord(log_severity=LogSeverity.ERROR,
                   message="This is a test log message",
-                  timestamp=datetime.datetime.now())
+                  timestamp=datetime.datetime.now(tzlocal()))
 
     with pytest.raises(ValueError):
         LogRecord(log_severity=LogSeverity.INFO,
                   message="This is a test log message",
-                  timestamp=datetime.datetime.now(),
+                  timestamp=datetime.datetime.now(tzlocal()),
                   stack_trace="This is a test stack trace")
 
 


### PR DESCRIPTION
Unfortunately, at the moment beanie can't retrieve timezone from mongodb, so after each data retrieving that conteins datetime, we need manually to add default timezone that is used in mongodb (UTC).
For example see file;
.../backend/mapping_package/services/api.py

```python
  for item in items:
      item.created_at = item.created_at.astimezone(timezone('UTC'))
``` 