### PR TITLE
encrease task timeout to 2 hours

### DIFF
--- a/mapping_workbench/backend/config/__init__.py
+++ b/mapping_workbench/backend/config/__init__.py
@@ -89,7 +89,7 @@ class TaskManagerSettings(BaseSettings):
     def TASK_MANAGER_MAX_WORKERS(self, config_value: str) -> int:
         return int(config_value)
 
-    @env_property(config_key='MW_TASK_TIMEOUT', default_value="2000")
+    @env_property(config_key='MW_TASK_TIMEOUT', default_value="7200")
     def TASK_TIMEOUT(self, config_value: str) -> int:
         return int(config_value)
 


### PR DESCRIPTION
There is no way to test this at the moment. This number is based on last package processing, which took ~40 min each in parallel.